### PR TITLE
Fix: update product command to use any .pivotal file in product folder

### DIFF
--- a/pcfup
+++ b/pcfup
@@ -214,14 +214,14 @@ function commandProduct() {
   PRODUCT_DOWNLOAD_FOLDER=$DOWNLOADS_FOLDER/$PRODUCT/$VERSION
 
   mkdir -p $PRODUCT_DOWNLOAD_FOLDER
-  if [[ $(ls -1 $PRODUCT_DOWNLOAD_FOLDER/$PRODUCT*.pivotal || echo "1") == "1" ]]; then
+  if [[ $(ls -1 $PRODUCT_DOWNLOAD_FOLDER/*.pivotal || echo "1") == "1" ]]; then
     logInfo "download $PRODUCT ($VERSION) from pivnet..."
     execPivnet download-product-files -p $PRODUCT -r $VERSION -d $PRODUCT_DOWNLOAD_FOLDER --glob=*.pivotal --accept-eula
   else
     logInfo "use cached version from $PRODUCT_DOWNLOAD_FOLDER"
   fi
   
-  PRODUCT_FILE=$(ls -1 $PRODUCT_DOWNLOAD_FOLDER/$PRODUCT*.pivotal | head -1)
+  PRODUCT_FILE=$(ls -1 $PRODUCT_DOWNLOAD_FOLDER/*.pivotal | head -1)
   logDebug "parse $PRODUCT_FILE to determine the necessary stemcell version."
   
   PRODUCT_METADATA=$(mktemp)


### PR DESCRIPTION
Previously the command required $PRODUCT prefix, however product and file names may have different cases. Example for [Single Sign-On for PCF](https://network.pivotal.io/products/pivotal_single_sign-on_service): 

```bash
$ ./pcfup product pivotal_single_sign-on_service 1.3.6
[INFO] download pivotal_single_sign-on_service (1.3.6) from pivnet...
2018/02/07 14:58:16 Downloading 'Pivotal_Single_Sign-On_Service_1.3.6.pivotal' to 'downloads/pivotal_single_sign-on_service/1.3.6/Pivotal_Single_Sign-On_Service_1.3.6.pivotal'
 32.19 MB / 32.19 MB [==============================================] 100.00% 1s
ls: cannot access downloads/pivotal_single_sign-on_service/1.3.6/pivotal_single_sign-on_service*.pivotal: No such file or directory
```

The downloaded file is called `Pivotal_Single_Sign-On_Service_1.3.6.pivotal` while `ls` is trying to match `pivotal_single_sign-on_service*.pivotal`, which will not work. A working solution would be to only match a `*.pivotal` file in a product folder.